### PR TITLE
fix: Add support for random resource type

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,19 @@
+# run python unit tests on PR
+name: PR
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Run tests
+        run: |
+          python3 -m unittest test_diff_refactor.py
+          python3 -m unittest test_plan_refactor.py

--- a/fixtures/tfplan
+++ b/fixtures/tfplan
@@ -421,6 +421,43 @@ Terraform will perform the following actions:
         }
     }
 
+  # module.docdb_05536A7B.random_password.master[0] will be created
+  + resource "random_password" "master" {
+      + bcrypt_hash      = (sensitive value)
+      + id               = (known after apply)
+      + length           = 16
+      + lower            = true
+      + min_lower        = 0
+      + min_numeric      = 0
+      + min_special      = 0
+      + min_upper        = 0
+      + number           = true
+      + numeric          = true
+      + override_special = "!#$%&*()-_=+[]{}<>:?"
+      + result           = (sensitive value)
+      + special          = true
+      + upper            = true
+    }
+
+  # module.prd-foo-docdb_03006172.random_password.master[0] will be destroyed
+  # (because random_password.master is not in configuration)
+  - resource "random_password" "master" {
+      - bcrypt_hash      = (sensitive value) -> null
+      - id               = "none" -> null
+      - length           = 16 -> null
+      - lower            = true -> null
+      - min_lower        = 0 -> null
+      - min_numeric      = 0 -> null
+      - min_special      = 0 -> null
+      - min_upper        = 0 -> null
+      - number           = true -> null
+      - numeric          = true -> null
+      - override_special = "!#$%&*()-_=+[]{}<>:?" -> null
+      - result           = (sensitive value) -> null
+      - special          = true -> null
+      - upper            = true -> null
+    }
+
   # aws_lambda_function.required-tags-reports_config-lambda_fn_A4B30528 will be destroyed
   # (because aws_lambda_function.required-tags-reports_config-lambda_fn_A4B30528 is not in configuration)
   - resource "aws_lambda_function" "required-tags-reports_config-lambda_fn_A4B30528" {

--- a/fixtures/tfplan_refactor.tf
+++ b/fixtures/tfplan_refactor.tf
@@ -47,3 +47,9 @@ moved {
   from = aws_lambda_function.required-tags-reports_config-lambda_fn_A4B30528
   to   = aws_lambda_function.required-tags-reports_config-lambda_fn
 }
+
+# rename module.prd-foo-docdb_03006172.random_password.master[0]
+moved {
+  from = module.prd-foo-docdb_03006172.random_password.master[0]
+  to   = module.docdb_05536A7B.random_password.master[0]
+}

--- a/plan_refactor.py
+++ b/plan_refactor.py
@@ -3,7 +3,7 @@ import re
 
 
 def generate_refactor(tfplan_output):
-    resource_action_pattern = re.compile(r'# (.*)(aws_[^.]*)\.(.*) will be (created|destroyed)')
+    resource_action_pattern = re.compile(r'# (.*)((?:random|aws)_[^.]*)\.(.*) will be (created|destroyed)')
     matches = resource_action_pattern.findall(tfplan_output)
 
     if not matches:


### PR DESCRIPTION
Add non-capturing group that matches both `aws_` and `random_` resource types: `(?:aws|random)` to action pattern regex.

Ideally a better regex is found, but this is quickfix

fixes:
- #1 
